### PR TITLE
fix(aspect-ratio): use vue-tsc to emit declaration files

### DIFF
--- a/packages/components/aspect-ratio/package.json
+++ b/packages/components/aspect-ratio/package.json
@@ -15,14 +15,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "require": "./dist/aspect-ratio.cjs",
       "import": "./dist/aspect-ratio.js"
     }
   },
   "main": "dist/aspect-ratio.cjs",
   "module": "dist/aspect-ratio.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "README.md"
@@ -30,6 +30,7 @@
   "scripts": {
     "clean": "rm -rf dist",
     "build": "vite build --mode production",
+    "types": "vue-tsc --declaration --emitDeclarationOnly",
     "dev": "vite build --mode production --watch",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"

--- a/packages/components/aspect-ratio/src/AspectRatio.vue
+++ b/packages/components/aspect-ratio/src/AspectRatio.vue
@@ -1,17 +1,11 @@
 <script lang="ts" setup>
 import { ref } from 'vue'
-import type { ComponentPropsWithoutRef, ElementRef } from '@oku-ui/primitive'
 import { Primitive } from '@oku-ui/primitive'
 
-export type PrimitiveAspectRatioProps = ComponentPropsWithoutRef<typeof Primitive.div>
-export type AspectRatioElement = ElementRef<typeof Primitive.div>
-
-export interface AspectRatioProps extends PrimitiveAspectRatioProps {
-  ratio?: number
-}
+import type { AspectRatioElement, AspectRatioProps } from './types'
 
 withDefaults(defineProps<AspectRatioProps>(), {
-  ratio: 1 / 1,
+  ratio: 1,
 })
 
 defineOptions({
@@ -32,10 +26,13 @@ defineExpose({
       position: 'relative',
       width: '100%',
       paddingBottom: `${100 / ratio}%`,
-    }" data-radix-aspect-ratio-wrapper
+    }"
+    data-radix-aspect-ratio-wrapper
   >
     <Primitive.div
-      v-bind="$attrs" ref="forwardedRef" :style="{
+      v-bind="$attrs"
+      ref="forwardedRef"
+      :style="{
         position: 'absolute',
         top: 0,
         right: 0,

--- a/packages/components/aspect-ratio/src/aspect-ratio.stories.ts
+++ b/packages/components/aspect-ratio/src/aspect-ratio.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 
-import type { AspectRatioProps } from './AspectRatio.vue'
+import type { AspectRatioProps } from './types'
 import OkuAspectRatio from './AspectRatio.vue'
 
 interface StoryProps extends AspectRatioProps {
@@ -13,10 +13,10 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     // TODO: ratio number '16 / 9' not working how to send a string? with storybook controls
-    ratio: { type: 'number', defaultValue: '1' },
+    ratio: { type: 'number', defaultValue: 1 },
   },
   // TODO: ratio number '16 / 9' not working how to send a string? with storybook controls
-  args: { ratio: '1' },
+  args: { ratio: 1 },
   // TODO: `render` ts props same problem as above
   render: (args: StoryProps) => ({
     components: { OkuAspectRatio },
@@ -38,14 +38,14 @@ const meta = {
       </div>
     `,
   }),
-} satisfies Meta<typeof OkuAspectRatio>
+} as Meta<StoryProps>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
 export const Primary: Story = {
   args: {
-    ratio: '1',
+    ratio: 1,
     imageurl: 'https://images.unsplash.com/photo-1535025183041-0991a977e25b?w=300&dpr=2&q=80',
   },
 }

--- a/packages/components/aspect-ratio/src/env.d.ts
+++ b/packages/components/aspect-ratio/src/env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+/// <reference types="vue/macros-global" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}

--- a/packages/components/aspect-ratio/src/index.ts
+++ b/packages/components/aspect-ratio/src/index.ts
@@ -1,3 +1,2 @@
-import AspectRatio from './AspectRatio.vue'
-
-export { AspectRatio }
+export * from './AspectRatio.vue'
+export * from './types'

--- a/packages/components/aspect-ratio/src/types.ts
+++ b/packages/components/aspect-ratio/src/types.ts
@@ -1,0 +1,8 @@
+import type { ComponentPropsWithoutRef, ElementRef, Primitive } from '@oku-ui/primitive'
+
+export type PrimitiveAspectRatioProps = ComponentPropsWithoutRef<typeof Primitive.div>
+export type AspectRatioElement = ElementRef<typeof Primitive.div>
+
+export interface AspectRatioProps extends PrimitiveAspectRatioProps {
+  ratio?: number
+}

--- a/packages/components/aspect-ratio/tsconfig.json
+++ b/packages/components/aspect-ratio/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "./../../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "declarationDir": "./dist"
   },
+  "exclude": ["node_modules", "dist", "src/**/*.stories.ts"],
   "include": [
-    "./"
+    "./src/**/*"
   ]
 }

--- a/packages/components/aspect-ratio/vite.config.ts
+++ b/packages/components/aspect-ratio/vite.config.ts
@@ -1,12 +1,10 @@
-import path, { resolve } from 'node:path'
+import path from 'node:path'
 
 import Vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 
-// https://github.com/qmhc/vite-plugin-dts
-import dtsPlugin from 'vite-plugin-dts'
-
 // https://github.com/sxzz/unplugin-vue-macros
+// @ts-expect-error - Missing types?
 import VueMacros from 'unplugin-vue-macros/vite'
 
 import * as pkg from './package.json'
@@ -17,24 +15,12 @@ const externals = [
 ]
 export default defineConfig({
   plugins: [
-    dtsPlugin({
-      include: ['./src/**/*.ts', './src/**/*.tsx', './src/**/*.vue'],
-      skipDiagnostics: false,
-      staticImport: true,
-      outputDir: ['./dist/types'],
-      cleanVueFileName: false,
-    }),
     VueMacros({
       plugins: {
         vue: Vue(),
       },
     }),
   ],
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, 'src'),
-    },
-  },
   build: {
     lib: {
       entry: path.resolve(__dirname, './src/index.ts'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,39 +1,40 @@
 {
-    "$schema": "https://json.schemastore.org/tsconfig",
-    "display": "Default",
-    "compilerOptions": {
-        "baseUrl": ".",
-        "target": "esnext",
-        "useDefineForClassFields": true,
-        "module": "esnext",
-        "moduleResolution": "node",
-        "isolatedModules": true,
-        "strict": true,
-        "jsx": "preserve",
-        "sourceMap": true,
-        "resolveJsonModule": true,
-        "esModuleInterop": true,
-        "lib": [
-            "esnext",
-            "dom"
-        ],
-        "skipLibCheck": true,
-        "outDir": "dist",
-        "noUnusedLocals": true,
-        "strictNullChecks": true,
-        "types": [
-            "vue",
-            "vite/client",
-            "unplugin-vue-macros/macros-global"
-        ]
-    },
-    "vueCompilerOptions": {
-        "plugins": [
-            "@vue-macros/volar/define-model",
-            "@vue-macros/volar/define-slots"
-        ]
-    },
-    "include": [
-        "packages/**/*"
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "strict": true,
+    "jsx": "preserve",
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "lib": [
+      "esnext",
+      "dom"
+    ],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "outDir": "dist",
+    "noUnusedLocals": true,
+    "strictNullChecks": true,
+    "types": [
+      "vue",
+      "vite/client",
+      "unplugin-vue-macros/macros-global"
     ]
+  },
+  "vueCompilerOptions": {
+    "plugins": [
+      "@vue-macros/volar/define-model",
+      "@vue-macros/volar/define-slots"
+    ]
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -3,10 +3,19 @@
   "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
-      "outputs": ["dist"]
+      "dependsOn": ["^build", "types"],
+      "outputs": ["dist/**"]
     },
-    "lint": {},
-    "lint:fix": {},
+    "types": {
+      "dependsOn": [],
+      "outputs": ["dist/**"]
+    },
+    "lint": {
+      "outputs": []
+    },
+    "lint:fix": {
+      "outputs": []
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
# What's changed?

* use vue-tsc to emit type declaration files
* move component prop types to separate file
* remove unnecessary config from vite.config
* update base tsconfig
* add types to build step in turbo config 