### PR TITLE
refactor: replace as-child prop with as="template" in various components

### DIFF
--- a/.docs/.vitepress/components/InstallationTabs.vue
+++ b/.docs/.vitepress/components/InstallationTabs.vue
@@ -37,7 +37,7 @@ defineProps<{
         v-for="pkg in PACKAGE_MANAGERS"
         :key="pkg"
         :value="pkg"
-        as-child
+        as="template"
       >
         <slot :name="pkg" />
       </TabsContent>

--- a/.docs/.vitepress/components/NewHeroCodeGroup.vue
+++ b/.docs/.vitepress/components/NewHeroCodeGroup.vue
@@ -149,7 +149,7 @@ watch(open, () => {
         v-for="tab in tabs"
         :key="tab.label"
         :value="tab.label"
-        as-child
+        as="template"
       >
         <div class="relative -mt-5 text-base">
           <component

--- a/.docs/components/Tooltip.vue
+++ b/.docs/components/Tooltip.vue
@@ -11,7 +11,7 @@ defineProps<{
     <TooltipRoot>
       <TooltipTrigger
         class="text-white hover:text-mauve12 focus:text-mauve12 shadow-blackA7 focus:bg-indigo3 hover:bg-indigo3 inline-flex h-[35px] w-[35px] items-center justify-center rounded-full shadow-none outline-none focus:shadow-[0_0_0_2px] focus:shadow-black"
-        as-child
+        as="template"
       >
         <slot />
       </TooltipTrigger>

--- a/.docs/components/demo/ContextMenu/css/index.vue
+++ b/.docs/components/demo/ContextMenu/css/index.vue
@@ -32,7 +32,7 @@ function handleClick() {
 <template>
   <ContextMenuRoot>
     <ContextMenuTrigger
-      as-child
+      as="template"
       class="ContextMenuTrigger"
     >
       <span> Right click here. </span>

--- a/.docs/components/demo/ContextMenu/tailwind/index.vue
+++ b/.docs/components/demo/ContextMenu/tailwind/index.vue
@@ -31,7 +31,7 @@ function handleClick() {
 <template>
   <ContextMenuRoot>
     <ContextMenuTrigger
-      as-child
+      as="template"
       class="block border-2 border-white border-dashed text-white rounded text-[15px] select-none py-[45px] w-[300px] text-center"
     >
       <span> Right click here. </span>

--- a/.docs/components/demo/Dialog/css/index.vue
+++ b/.docs/components/demo/Dialog/css/index.vue
@@ -54,7 +54,7 @@ import './styles.css'
           >
         </fieldset>
         <div :style="{ display: 'flex', marginTop: 25, justifyContent: 'flex-end' }">
-          <DialogClose as-child>
+          <DialogClose as="template">
             <button
               class="Button green"
             >

--- a/.docs/components/demo/Dialog/tailwind/index.vue
+++ b/.docs/components/demo/Dialog/tailwind/index.vue
@@ -53,7 +53,7 @@ import { Icon } from '@iconify/vue'
           >
         </fieldset>
         <div class="mt-[25px] flex justify-end">
-          <DialogClose as-child>
+          <DialogClose as="template">
             <button
               class="bg-indigo4 text-indigo11 hover:bg-indigo5 focus:shadow-indigo7 inline-flex h-[35px] items-center justify-center rounded-[4px] px-[15px] font-semibold leading-none focus:shadow-[0_0_0_2px] focus:outline-none"
             >

--- a/.docs/components/demo/DialogNested/tailwind/index.vue
+++ b/.docs/components/demo/DialogNested/tailwind/index.vue
@@ -33,7 +33,7 @@ import { Icon } from '@iconify/vue'
           </DialogDescription>
 
           <div class="mt-[25px] flex gap-4 justify-end">
-            <DialogClose as-child>
+            <DialogClose as="template">
               <button
                 class="bg-indigo4 text-indigo11 hover:bg-indigo5 focus:shadow-indigo7 inline-flex h-[35px] items-center justify-center rounded-[4px] px-[15px] font-semibold leading-none focus:shadow-[0_0_0_2px] focus:outline-none"
               >
@@ -61,7 +61,7 @@ import { Icon } from '@iconify/vue'
                   </DialogDescription>
 
                   <div class="flex justify-end">
-                    <DialogClose as-child>
+                    <DialogClose as="template">
                       <button
                         class="bg-indigo4 text-indigo11 hover:bg-indigo5 focus:shadow-indigo7 inline-flex h-[35px] items-center justify-center rounded-[4px] px-[15px] font-semibold leading-none focus:shadow-[0_0_0_2px] focus:outline-none"
                       >

--- a/.docs/components/demo/Toast/css/index.vue
+++ b/.docs/components/demo/Toast/css/index.vue
@@ -44,7 +44,7 @@ useToastProvider()
       <ToastTitle class="ToastTitle">
         Scheduled: Catch up
       </ToastTitle>
-      <ToastDescription as-child>
+      <ToastDescription as="template">
         <time
           class="ToastDescription"
           :dateTime="eventDateRef.toISOString()"
@@ -54,7 +54,7 @@ useToastProvider()
       </ToastDescription>
       <ToastAction
         class="ToastAction"
-        as-child
+        as="template"
         alt-text="Goto schedule to undo"
       >
         <button class="Button small green">

--- a/.docs/components/demo/Toast/tailwind/index.vue
+++ b/.docs/components/demo/Toast/tailwind/index.vue
@@ -42,7 +42,7 @@ useToastProvider()
     <ToastTitle class="[grid-area:_title] mb-[5px] font-medium text-slate12 text-[15px]">
       Scheduled: Catch up
     </ToastTitle>
-    <ToastDescription as-child>
+    <ToastDescription as="template">
       <time
         class="[grid-area:_description] m-0 text-slate11 text-[13px] leading-[1.3]"
         :dateTime="eventDateRef.toISOString()"
@@ -52,7 +52,7 @@ useToastProvider()
     </ToastDescription>
     <ToastAction
       class="[grid-area:_action]"
-      as-child
+      as="template"
       alt-text="Goto schedule to undo"
     >
       <button class="inline-flex items-center justify-center rounded font-medium text-xs px-[10px] leading-[25px] h-[25px] bg-indigo2 text-indigo11 shadow-[inset_0_0_0_1px] shadow-indigo7 hover:shadow-[inset_0_0_0_1px] hover:shadow-indigo8 focus:shadow-[0_0_0_2px] focus:shadow-indigo8">

--- a/.docs/components/demo/Tooltip/css/index.vue
+++ b/.docs/components/demo/Tooltip/css/index.vue
@@ -14,7 +14,7 @@ import './styles.css'
       </TooltipTrigger>
       <TooltipPortal>
         <TooltipContent
-          as-child
+          as="template"
           class="TooltipContent"
           :side-offset="5"
         >

--- a/.docs/content/components/accordion.md
+++ b/.docs/content/components/accordion.md
@@ -91,7 +91,7 @@ Contains all the parts of a collapsible section.
 
 ### Header
 
-Wraps an `AccordionTrigger`. Use the `asChild` prop to update it to the appropriate heading level for your page.
+Wraps an `AccordionTrigger`. Use the `as="template"` prop to update it to the appropriate heading level for your page.
 
 <!-- @include: @/meta/AccordionHeader.md -->
 

--- a/.docs/content/components/dialog.md
+++ b/.docs/content/components/dialog.md
@@ -134,7 +134,7 @@ The button that closes the dialog
 
 An accessible title to be announced when the dialog is opened.
 
-If you want to hide the title, wrap it inside our Visually Hidden utility like this `<VisuallyHidden asChild>`.
+If you want to hide the title, wrap it inside our Visually Hidden utility like this `<VisuallyHidden as="template">`.
 
 <!-- @include: @/meta/DialogTitle.md -->
 
@@ -142,7 +142,7 @@ If you want to hide the title, wrap it inside our Visually Hidden utility like t
 
 An optional accessible description to be announced when the dialog is opened.
 
-If you want to hide the description, wrap it inside our Visually Hidden utility like this `<VisuallyHidden asChild>`. If you want to remove the description entirely, remove this part and pass `:aria-describedby="undefined"` to `DialogContent`.
+If you want to hide the description, wrap it inside our Visually Hidden utility like this `<VisuallyHidden as="template">`. If you want to remove the description entirely, remove this part and pass `:aria-describedby="undefined"` to `DialogContent`.
 
 <!-- @include: @/meta/DialogDescription.md -->
 

--- a/.docs/content/components/popover.md
+++ b/.docs/content/components/popover.md
@@ -299,7 +299,7 @@ import { PopoverAnchor, PopoverArrow, PopoverClose, PopoverContent, PopoverPorta
 
 <template>
   <PopoverRoot>
-    <PopoverAnchor as-child>
+    <PopoverAnchor as="template">
       <div class="Row">
         Row as anchor <PopoverTrigger>Trigger</PopoverTrigger>
       </div>

--- a/.docs/content/components/toast.md
+++ b/.docs/content/components/toast.md
@@ -368,7 +368,7 @@ defineProps<{
     </ToastTitle>
     <ToastDescription>{{ content }}</ToastDescription>
     <ToastAction
-      as-child
+      as="template"
       alt-text="toast"
     >
       <slot />

--- a/.docs/content/components/toolbar.md
+++ b/.docs/content/components/toolbar.md
@@ -148,7 +148,7 @@ Used to visually separate items in the toolbar
 
 ### Use with other primitives
 
-All our primitives which expose a `Trigger` part, such as `Dialog`, `AlertDialog`, `Popover`, `DropdownMenu` can be composed within a toolbar by using the [`asChild` prop](/guides/composition).
+All our primitives which expose a `Trigger` part, such as `Dialog`, `AlertDialog`, `Popover`, `DropdownMenu` can be composed within a toolbar by using the [`as="template"` prop](/guides/composition).
 
 Here is an example using our `DropdownMenu` primitive.
 
@@ -172,7 +172,7 @@ import {
     <ToolbarButton>Action 1</ToolbarButton>
     <ToolbarSeparator />
     <DropdownMenuRoot>
-      <ToolbarButton as-child>
+      <ToolbarButton as="template">
         <DropdownMenuTrigger>Trigger</DropdownMenuTrigger>
       </ToolbarButton>
       <DropdownMenuContent>…</DropdownMenuContent>

--- a/.docs/content/components/tooltip.md
+++ b/.docs/content/components/tooltip.md
@@ -194,7 +194,7 @@ import { TooltipContent, TooltipProvider, TooltipRoot, TooltipTrigger } from '@o
 
 <template>
   <TooltipRoot>
-    <TooltipTrigger as-child>
+    <TooltipTrigger as="template">
       <span tabindex="0">
         <button
           disabled
@@ -386,7 +386,7 @@ import { Tooltip } from './your-tooltip'
 
 #### Implementation
 
-Use the [`asChild` prop](/guides/composition) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
+Use the [`as="template"` prop](/guides/composition) to convert the trigger part into a slottable area. It will replace the trigger with the child that gets passed to it.
 
 ```vue line=13-15
 <!-- your-tooltip.vue  -->
@@ -401,7 +401,7 @@ const forward = useForwardPropsEmits(props, emits)
 
 <template>
   <TooltipRoot v-bind="forward">
-    <TooltipTrigger as-child>
+    <TooltipTrigger as="template">
       <slot />
     </TooltipTrigger>
     <TooltipContent

--- a/.docs/content/overview/introduction.md
+++ b/.docs/content/overview/introduction.md
@@ -52,7 +52,7 @@ Where applicable, components are uncontrolled by default but can also be control
 
 ### Developer experience
 
-One of our main goals is to provide the best possible developer experience. Radix Primitives provides a fully-typed API. All components share a similar API, creating a consistent and predictable experience. We've also implemented an `asChild` prop (It's not a problem for Vue), giving users full control over the rendered element.
+One of our main goals is to provide the best possible developer experience. Radix Primitives provides a fully-typed API. All components share a similar API, creating a consistent and predictable experience. We've also implemented an `as="template"` prop (It's not a problem for Vue), giving users full control over the rendered element.
 
 ### Tree-shaking friendly
 

--- a/.docs/content/utilities/primitive.md
+++ b/.docs/content/utilities/primitive.md
@@ -23,7 +23,7 @@ When you are building a component, in some cases you might want to allow user to
       description: 'The element or component the current element should render as.',
     },
     {
-      name: 'as="template"',
+      name: "as=\"template\"",
       required: false,
       type: 'boolean',
       default: 'false',

--- a/.docs/content/utilities/primitive.md
+++ b/.docs/content/utilities/primitive.md
@@ -23,7 +23,7 @@ When you are building a component, in some cases you might want to allow user to
       description: 'The element or component the current element should render as.',
     },
     {
-      name: 'asChild',
+      name: 'as="template"',
       required: false,
       type: 'boolean',
       default: 'false',
@@ -55,6 +55,6 @@ const props = withDefaults(defineProps<PrimitiveProps>(), {
 </template>
 ```
 
-### Render `asChild`
+### Render `as="template"`
 
 Change the default rendered element for the one passed as a child, merging their props and behavior.<br><br>Read our <a href="/guides/composition">Composition</a> guide for more details.

--- a/.docs/content/utilities/primitive.md
+++ b/.docs/content/utilities/primitive.md
@@ -6,7 +6,9 @@ description: Compose Radix's functionality onto alternative element types or you
 # Primitive
 
 <Description>
+
 Compose Radix's functionality onto alternative element types or your own Vue components.
+
 </Description>
 
 When you are building a component, in some cases you might want to allow user to compose some functionalities onto the underlying element, or alternative element. This is where `Primitive` comes in handy as it expose this capability to the user.
@@ -23,7 +25,7 @@ When you are building a component, in some cases you might want to allow user to
       description: 'The element or component the current element should render as.',
     },
     {
-      name: "as=\"template\"",
+      name: 'as=\'template\'',
       required: false,
       type: 'boolean',
       default: 'false',
@@ -55,6 +57,6 @@ const props = withDefaults(defineProps<PrimitiveProps>(), {
 </template>
 ```
 
-### Render `as="template"`
+### Render "as=\"template\""
 
 Change the default rendered element for the one passed as a child, merging their props and behavior.<br><br>Read our <a href="/guides/composition">Composition</a> guide for more details.

--- a/.docs/content/utilities/visually-hidden.md
+++ b/.docs/content/utilities/visually-hidden.md
@@ -64,7 +64,7 @@ Anything you put inside this component will be hidden from the screen but will b
       description: 'The element or component this component should render as. Can be overwrite by <Code>as="template"</Code>'
     },
     {
-      name: 'as="template"',
+      name: "as=\"template\"",
       required: false,
       type: 'boolean',
       default: 'false',

--- a/.docs/content/utilities/visually-hidden.md
+++ b/.docs/content/utilities/visually-hidden.md
@@ -37,8 +37,10 @@ Use the visually hidden primitive.
 
 ```vue
 <script setup lang="ts">
+
 import { VisuallyHidden } from '@oku-ui/primitives'
 import { GearIcon } from '@radix-icons/vue'
+
 </script>
 
 <template>
@@ -61,10 +63,10 @@ Anything you put inside this component will be hidden from the screen but will b
       name: 'as',
       type: 'string | Component',
       default: 'span',
-      description: 'The element or component this component should render as. Can be overwrite by <Code>as="template"</Code>'
+      description: 'The element or component this component should render as. Can be overwrite by <Code>as=\'template\'</Code>'
     },
     {
-      name: "as=\"template\"",
+      name: 'as=\'template\'',
       required: false,
       type: 'boolean',
       default: 'false',

--- a/.docs/content/utilities/visually-hidden.md
+++ b/.docs/content/utilities/visually-hidden.md
@@ -61,10 +61,10 @@ Anything you put inside this component will be hidden from the screen but will b
       name: 'as',
       type: 'string | Component',
       default: 'span',
-      description: 'The element or component this component should render as. Can be overwrite by <Code>asChild</Code>'
+      description: 'The element or component this component should render as. Can be overwrite by <Code>as="template"</Code>'
     },
     {
-      name: 'asChild',
+      name: 'as="template"',
       required: false,
       type: 'boolean',
       default: 'false',


### PR DESCRIPTION
This pull request involves a comprehensive update to replace the `as-child` prop with `as="template"` across various Vue component files and documentation. This change ensures consistency and improves the developer experience by providing a unified approach to rendering elements or components.

The most important changes include:

### Component Updates:
* [`.docs/.vitepress/components/InstallationTabs.vue`](diffhunk://#diff-3ec7eeb17cd48f1dcd2c552032a5371a3e0c4763934dbb860116fb94cd1e3573L40-R40): Changed `as-child` to `as="template"` in `TabsContent` component.
* [`.docs/.vitepress/components/NewHeroCodeGroup.vue`](diffhunk://#diff-9b8bc95d12c0c3fe3f03038cb0b0f781f6f49d3885bfe759ff476061e16ac0cdL152-R152): Updated `as-child` to `as="template"` in the component rendering tabs.
* [`.docs/components/Tooltip.vue`](diffhunk://#diff-f936410ae24977844c0585da82b440192612142d777942bcff8410f249bcefc4L14-R14): Replaced `as-child` with `as="template"` in the `TooltipTrigger` component.
* [`.docs/components/demo/ContextMenu/css/index.vue`](diffhunk://#diff-f2e02dbbb5c096c64542ff1cfd68aba1d5110ed2d87a76a4915b738f412f9a9dL35-R35): Modified `as-child` to `as="template"` in the `ContextMenuTrigger` component.
* [`.docs/components/demo/Dialog/css/index.vue`](diffhunk://#diff-0e865fc9cb2aae590ec281671f969d4e280f75f69b08600f63cf753330b19b47L57-R57): Updated `DialogClose` component to use `as="template"` instead of `as-child`.

### Documentation Updates:
* [`.docs/content/components/accordion.md`](diffhunk://#diff-8dcaa6d0a99cc75417a712feb7aeebd0c65dead7a11ee524c3250306f80d83b5L94-R94): Changed references of `asChild` to `as="template"` in the `AccordionTrigger` section.
* [`.docs/content/components/dialog.md`](diffhunk://#diff-b651eedc61edcb69eaaebf111c662a556c8d3504c36a9a1cb8d41c14a04a410eL137-R145): Updated documentation to reflect the use of `as="template"` instead of `asChild` for hiding titles and descriptions.
* [`.docs/content/components/tooltip.md`](diffhunk://#diff-fe936486bdece6b4b768791c10cbc3d5b15d5c920785296156349ab140b4185bL389-R389): Replaced `asChild` with `as="template"` in multiple instances within the tooltip documentation. (F4a4cee5L14R14, [[1]](diffhunk://#diff-fe936486bdece6b4b768791c10cbc3d5b15d5c920785296156349ab140b4185bL389-R389) [[2]](diffhunk://#diff-fe936486bdece6b4b768791c10cbc3d5b15d5c920785296156349ab140b4185bL404-R404)
* [`.docs/content/overview/introduction.md`](diffhunk://#diff-5a1ea098320b43d63293c0f19b0e65b0304b887f4a7bc772cab7d385be75d688L55-R55): Updated introduction to mention the `as="template"` prop for better developer control.
* [`.docs/content/utilities/primitive.md`](diffhunk://#diff-4b7344cce504a6d676dd9c466c4c23304021221652bae8d0e39ac7a725195ee7L26-R26): Changed the description and usage of `asChild` to `as="template"` in the primitive utilities documentation. [[1]](diffhunk://#diff-4b7344cce504a6d676dd9c466c4c23304021221652bae8d0e39ac7a725195ee7L26-R26) [[2]](diffhunk://#diff-4b7344cce504a6d676dd9c466c4c23304021221652bae8d0e39ac7a725195ee7L58-R58)