### PR TITLE
feat: enhance Primitive component with SSR support and improved rende…

### DIFF
--- a/packages/core/src/primitive/Primitive.ts
+++ b/packages/core/src/primitive/Primitive.ts
@@ -1,4 +1,4 @@
-import { type Component, defineComponent, h, type PropType } from 'vue'
+import { type Component, computed, defineComponent, h, type PropType, useSSRContext, vShow, withDirectives } from 'vue'
 import { Slot } from '../slot/index.ts'
 
 export type AsTag =
@@ -34,20 +34,69 @@ export const Primitive = defineComponent({
     as: {
       type: [String, Object] as PropType<AsTag | Component>,
       default: 'div',
+      validator: (value: AsTag | Component) => {
+        if (typeof value === 'string') {
+          return true
+        }
+        return typeof value === 'object'
+      },
+    },
+    vapor: {
+      type: Boolean,
+      default: true,
     },
   },
   setup(props, ctx) {
-    const asChild = props.as === 'template'
-    if (asChild) {
-      return () => h(Slot, ctx.attrs, { default: ctx.slots.default })
+    const ssrContext = useSSRContext()
+    const isServer = !!ssrContext
+
+    const isTemplateElement = computed(() => props.as === 'template')
+    const isSingleElement = computed(() =>
+      typeof props.as === 'string' && singleHtmlTags.has(props.as),
+    )
+
+    const renderElement = () => {
+      try {
+        if (isTemplateElement.value) {
+          return h(Slot, ctx.attrs, { default: ctx.slots.default })
+        }
+
+        if (isSingleElement.value) {
+          return h(props.as, ctx.attrs)
+        }
+
+        return h(props.as, ctx.attrs, { default: ctx.slots.default })
+      }
+      catch (error) {
+        console.error(`Failed to render primitive element:`, error)
+        // Fallback to div if rendering fails
+        return h('div', ctx.attrs, { default: ctx.slots.default })
+      }
     }
 
-    const isSingleHtmlTag = typeof props.as === 'string' && singleHtmlTags.has(props.as)
+    const renderVaporElement = () => {
+      const baseElement = props.as || 'div'
+      const attrs = {
+        ...ctx.attrs,
+        _vapor: '',
+        _ssr: isServer ? '' : undefined,
+      }
 
-    if (isSingleHtmlTag) {
-      return () => h(props.as, ctx.attrs)
+      if (props.as === 'template') {
+        return withDirectives(h(Slot, attrs, {
+          default: ctx.slots.default,
+        }), [[vShow, true]])
+      }
+
+      if (typeof props.as === 'string' && singleHtmlTags.has(props.as)) {
+        return withDirectives(h(baseElement, attrs), [[vShow, true]])
+      }
+
+      return withDirectives(h(baseElement, attrs, {
+        default: ctx.slots.default,
+      }), [[vShow, true]])
     }
 
-    return () => h(props.as, ctx.attrs, { default: ctx.slots.default })
+    return props.vapor ? renderVaporElement : renderElement
   },
 })


### PR DESCRIPTION

- Added new imports: `computed`, `useSSRContext`, `vShow`, and `withDirectives` from Vue.
- Introduced a new boolean prop `vapor` with a default value of `true`.
- Added a validator for the `as` prop to ensure it's either a string or an object.
- Implemented `useSSRContext` for server-side rendering support.
- Created `computed` properties: `isTemplateElement` and `isSingleElement`.
- Developed two new rendering functions: `renderElement` and `renderVaporElement` with error handling and fallback mechanisms.
- Utilized `vShow` directive to control element visibility.
- Conditionally rendered elements based on the `vapor` prop.