### PR TITLE
chore: migrate Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     ":widenPeerDependencies"
   ],
   "baseBranches": [
@@ -15,7 +15,7 @@
     {
       "groupName": "all digest updates",
       "groupSlug": "all-digest",
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "automerge": true,
@@ -29,7 +29,7 @@
     {
       "groupName": "all minor updates",
       "groupSlug": "all-minor",
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "matchUpdateTypes": [
@@ -43,7 +43,7 @@
     {
       "groupName": "all patch updates",
       "groupSlug": "all-patch",
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "matchUpdateTypes": [
@@ -57,7 +57,7 @@
     {
       "groupName": "all major updates",
       "groupSlug": "all-major",
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "*"
       ],
       "matchUpdateTypes": [


### PR DESCRIPTION
## Summary
- migrate Renovate from the deprecated `config:base` preset to `config:recommended`
- replace deprecated `matchPackagePatterns` keys with `matchPackageNames`
- keep the existing schedules, automerge settings, grouping, base branch, and ignored dependencies unchanged

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

This addresses the Config Migration Needed item in the Renovate Dependency Dashboard.